### PR TITLE
feat: add mock implementation for MongoOperations in unit tests

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -2,7 +2,6 @@ package mongo
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -110,21 +109,4 @@ func BuildCollections() map[string]string {
 	}
 
 	return col
-}
-
-func GetMongoClient(ctx context.Context, m Mongo) (*mongo.Client, error) {
-	if time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
-		mb, err := Build(m.VaultDetails, vault_helper.NewVault(m.VaultDetails.Address, m.VaultDetails.Token))
-		if err != nil {
-			return nil, logs.Errorf("error re-building mongo: %v", err)
-		}
-		m = *mb
-	}
-
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(fmt.Sprintf("mongodb://%s:%s@%s", m.Username, m.Password, m.Host)))
-	if err != nil {
-		return nil, logs.Errorf("error connecting to mongo: %v", err)
-	}
-
-	return client, nil
 }

--- a/mongo/mongo_client.go
+++ b/mongo/mongo_client.go
@@ -1,0 +1,104 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+	"github.com/bugfixes/go-bugfixes/logs"
+	vault_helper "github.com/keloran/vault-helper"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"time"
+)
+
+type MongoOperations interface {
+	GetMongoClient(ctx context.Context, m Mongo) (*mongo.Client, error)
+	GetMongoDatabase(m Mongo) (*mongo.Database, error)
+	GetMongoCollection(m Mongo, collection string) (*mongo.Collection, error)
+	InsertOne(ctx context.Context, document interface{}) (*mongo.InsertOneResult, error)
+	InsertMany(ctx context.Context, documents []interface{}) (*mongo.InsertManyResult, error)
+	FindOne(ctx context.Context, filter interface{}) *mongo.SingleResult
+	Find(ctx context.Context, filter interface{}) (*mongo.Cursor, error)
+	UpdateOne(ctx context.Context, filter interface{}, update interface{}) (*mongo.UpdateResult, error)
+	UpdateMany(ctx context.Context, filter interface{}, update interface{}) (*mongo.UpdateResult, error)
+	DeleteOne(ctx context.Context, filter interface{}) (*mongo.DeleteResult, error)
+	DeleteMany(ctx context.Context, filter interface{}) (*mongo.DeleteResult, error)
+}
+
+type RealMongoOperations struct {
+	Client     *mongo.Client
+	Collection *mongo.Collection
+	Database   *mongo.Database
+}
+
+func (r *RealMongoOperations) GetMongoClient(ctx context.Context, m Mongo) (*mongo.Client, error) {
+	if time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
+		mb, err := Build(m.VaultDetails, vault_helper.NewVault(m.VaultDetails.Address, m.VaultDetails.Token))
+		if err != nil {
+			return nil, logs.Errorf("error re-building mongo: %v", err)
+		}
+		m = *mb
+	}
+
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(fmt.Sprintf("mongodb://%s:%s@%s", m.Username, m.Password, m.Host)))
+	if err != nil {
+		return nil, logs.Errorf("error connecting to mongo: %v", err)
+	}
+
+	return client, nil
+}
+
+func (r *RealMongoOperations) GetMongoDatabase(m Mongo) (*mongo.Database, error) {
+	if time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
+		mb, err := Build(m.VaultDetails, vault_helper.NewVault(m.VaultDetails.Address, m.VaultDetails.Token))
+		if err != nil {
+			return nil, logs.Errorf("error re-building mongo: %v", err)
+		}
+		m = *mb
+	}
+
+	return r.Client.Database(m.Database), nil
+}
+
+func (r *RealMongoOperations) GetMongoCollection(m Mongo, collection string) (*mongo.Collection, error) {
+	if time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
+		mb, err := Build(m.VaultDetails, vault_helper.NewVault(m.VaultDetails.Address, m.VaultDetails.Token))
+		if err != nil {
+			return nil, logs.Errorf("error re-building mongo: %v", err)
+		}
+		m = *mb
+	}
+
+	return r.Client.Database(m.Database).Collection(m.Collections[collection]), nil
+}
+
+func (r *RealMongoOperations) InsertOne(ctx context.Context, document interface{}) (*mongo.InsertOneResult, error) {
+	return r.Collection.InsertOne(ctx, document)
+}
+
+func (r *RealMongoOperations) InsertMany(ctx context.Context, documents []interface{}) (*mongo.InsertManyResult, error) {
+	return r.Collection.InsertMany(ctx, documents)
+}
+
+func (r *RealMongoOperations) FindOne(ctx context.Context, filter interface{}) *mongo.SingleResult {
+	return r.Collection.FindOne(ctx, filter)
+}
+
+func (r *RealMongoOperations) Find(ctx context.Context, filter interface{}) (*mongo.Cursor, error) {
+	return r.Collection.Find(ctx, filter)
+}
+
+func (r *RealMongoOperations) UpdateOne(ctx context.Context, filter interface{}, update interface{}) (*mongo.UpdateResult, error) {
+	return r.Collection.UpdateOne(ctx, filter, update)
+}
+
+func (r *RealMongoOperations) UpdateMany(ctx context.Context, filter interface{}, update interface{}) (*mongo.UpdateResult, error) {
+	return r.Collection.UpdateMany(ctx, filter, update)
+}
+
+func (r *RealMongoOperations) DeleteOne(ctx context.Context, filter interface{}) (*mongo.DeleteResult, error) {
+	return r.Collection.DeleteOne(ctx, filter)
+}
+
+func (r *RealMongoOperations) DeleteMany(ctx context.Context, filter interface{}) (*mongo.DeleteResult, error) {
+	return r.Collection.DeleteMany(ctx, filter)
+}

--- a/mongo/mongo_client_test.go
+++ b/mongo/mongo_client_test.go
@@ -1,0 +1,116 @@
+package mongo
+
+import (
+	"context"
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+	"testing"
+)
+
+type MockMongoOperations struct {
+	Client     *mongo.Client
+	Collection *mongo.Collection
+	Database   *mongo.Database
+}
+
+func (mock *MockMongoOperations) GetMongoClient(ctx context.Context, m Mongo) (*mongo.Client, error) {
+	if mock.Client == nil {
+		return nil, errors.New("mocked error: client is nil") // Return an error when client is nil
+	}
+	return mock.Client, nil
+}
+
+func (mock *MockMongoOperations) GetMongoDatabase(m Mongo) (*mongo.Database, error) {
+	// return your mocked Database and error here
+	if mock.Database == nil {
+		return nil, errors.New("mocked error: database is nil") // Return an error when database is nil
+	}
+
+	return mock.Database, nil
+}
+
+func (mock *MockMongoOperations) GetMongoCollection(m Mongo, collection string) (*mongo.Collection, error) {
+	// return your mocked Collection and error here
+	return mock.Collection, nil
+}
+
+func (mock *MockMongoOperations) InsertOne(ctx context.Context, document interface{}) (*mongo.InsertOneResult, error) {
+	// return your mocked InsertOneResult and error here
+	return &mongo.InsertOneResult{}, nil
+}
+
+func (mock *MockMongoOperations) InsertMany(ctx context.Context, documents []interface{}) (*mongo.InsertManyResult, error) {
+	// return your mocked InsertManyResult and error here
+	return &mongo.InsertManyResult{}, nil
+}
+
+func (mock *MockMongoOperations) FindOne(ctx context.Context, filter interface{}) *mongo.SingleResult {
+	// return your mocked SingleResult here
+	return &mongo.SingleResult{}
+}
+
+func (mock *MockMongoOperations) Find(ctx context.Context, filter interface{}) (*mongo.Cursor, error) {
+	// return your mocked Cursor and error here
+	return &mongo.Cursor{}, nil
+}
+
+func (mock *MockMongoOperations) UpdateOne(ctx context.Context, filter interface{}, update interface{}) (*mongo.UpdateResult, error) {
+	// return your mocked UpdateResult and error here
+	return &mongo.UpdateResult{}, nil
+}
+
+func (mock *MockMongoOperations) UpdateMany(ctx context.Context, filter interface{}, update interface{}) (*mongo.UpdateResult, error) {
+	// return your mocked UpdateResult and error here
+	return &mongo.UpdateResult{}, nil
+}
+
+func (mock *MockMongoOperations) DeleteOne(ctx context.Context, filter interface{}) (*mongo.DeleteResult, error) {
+	// return your mocked DeleteResult and error here
+	return &mongo.DeleteResult{}, nil
+}
+
+func (mock *MockMongoOperations) DeleteMany(ctx context.Context, filter interface{}) (*mongo.DeleteResult, error) {
+	// return your mocked DeleteResult and error here
+	return &mongo.DeleteResult{}, nil
+}
+
+func TestMockMongoOperations(t *testing.T) {
+	ctx := context.Background()
+
+	mongoOps := &MockMongoOperations{
+		Client:     &mongo.Client{},     // Your mocked implementation
+		Collection: &mongo.Collection{}, // Your mocked implementation
+		Database:   &mongo.Database{},   // Your mocked implementation
+	}
+
+	t.Run("Test GetMongoClient", func(t *testing.T) {
+		client, err := mongoOps.GetMongoClient(ctx, Mongo{})
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	mongoOps.Client = nil // To simulate error
+	t.Run("Test GetMongoClient Error", func(t *testing.T) {
+		_, err := mongoOps.GetMongoClient(ctx, Mongo{})
+		assert.Error(t, err)
+	})
+
+	t.Run("Test GetMongoDatabase", func(t *testing.T) {
+		db, err := mongoOps.GetMongoDatabase(Mongo{})
+		assert.NoError(t, err)
+		assert.NotNil(t, db)
+	})
+
+	mongoOps.Database = nil // To simulate error
+	t.Run("Test GetMongoDatabase Error", func(t *testing.T) {
+		_, err := mongoOps.GetMongoDatabase(Mongo{})
+		assert.Error(t, err)
+	})
+
+	t.Run("Test GetMongoCollection", func(t *testing.T) {
+		collection, err := mongoOps.GetMongoCollection(Mongo{}, "collection")
+		assert.NoError(t, err)
+		assert.NotNil(t, collection)
+	})
+}


### PR DESCRIPTION
The commit adds a mock implementation for the `MongoOperations` interface in the `mongo` package. This mock implementation is used in unit tests to simulate interactions with a MongoDB database without actually connecting to a real database. The mock implementation provides methods for getting a Mongo client, database, and collection, as well as performing insert, find, update, and delete operations. The commit also includes a test case to verify the functionality of the mock implementation.