### PR TITLE
feat: add support for project-specific configuration during build process

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	keycloak.Keycloak
 	mongo.Mongo
 	rabbit.Rabbit
+	ProjectConfigurator
 }
 
 type BuildOption func(*Config) error
@@ -132,4 +133,19 @@ func (c *Config) Build(opts ...BuildOption) error {
 	}
 
 	return nil
+}
+
+// Project Configurators
+type ProjectConfigurator interface {
+	Build(opts ...BuildOption) error
+}
+
+func WithProjectConfigurator(pc ProjectConfigurator) BuildOption {
+	return func(c *Config) error {
+		if err := pc.Build(); err != nil {
+			return logs.Errorf("withProjectConfigurator: %v", err)
+		}
+
+		return nil
+	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -164,3 +164,35 @@ func TestMongo(t *testing.T) {
 		assert.Equal(t, "testUser", cfg.Mongo.Username)
 	})
 }
+
+// Assuming ProjectConfigurator interface and Config structure are defined as shown previously
+
+// MockProjectConfigurator is a mock implementation for testing purposes.
+type MockProjectConfigurator struct{}
+
+// Build simulates applying project-specific configurations.
+func (mpc *MockProjectConfigurator) Build(opts ...BuildOption) error {
+	if err := os.Setenv("PROJECT_SPECIFIC_CONFIG", "true"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestProjectConfig(t *testing.T) {
+	t.Run("project configuration", func(t *testing.T) {
+		os.Clearenv()
+
+		// Assuming this mock sets an environment variable as part of its configuration logic
+		mockProjectConfigurator := MockProjectConfigurator{}
+		mockLocalProject := WithProjectConfigurator(&mockProjectConfigurator)
+
+		// Build configuration including the mock project configurator
+		_, err := Build(mockLocalProject)
+		assert.NoError(t, err)
+
+		// Verify the project-specific configuration was recognized
+		projectSpecificConfig, exists := os.LookupEnv("PROJECT_SPECIFIC_CONFIG")
+		assert.True(t, exists)
+		assert.Equal(t, "true", projectSpecificConfig)
+	})
+}


### PR DESCRIPTION
- Added `ProjectConfigurator` interface to define project-specific configurators
- Added `WithProjectConfigurator` function to include a project configurator as a build option
- Updated `Config` struct to include `ProjectConfigurator` field
- Added `MockProjectConfigurator` struct as a mock implementation for testing
- Added `Build` method to `MockProjectConfigurator` to simulate applying project-specific configurations
- Added test case `TestProjectConfig` to verify that project-specific configuration is recognized during build