### PR TITLE
feat: add support for specifying a single collection in Mongo struct and update GetMongoClient function to handle dynamic collection name

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -112,7 +112,7 @@ func BuildCollections() map[string]string {
 	return col
 }
 
-// Deprecated: As of ConfigBuilder v0.5.0, RealMongoOperations.GetMongoClient
+// Deprecated: As of ConfigBuilder v0.5.0, use RealMongoOperations.GetMongoClient
 func GetMongoClient(ctx context.Context, m Mongo) (*mongo.Client, error) {
 	if time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
 		mb, err := Build(m.VaultDetails, vaultHelper.NewVault(m.VaultDetails.Address, m.VaultDetails.Token))

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -27,6 +27,7 @@ type Mongo struct {
 	Database string `env:"MONGO_DB" envDefault:""`
 
 	Collections map[string]string
+	Collection  string
 
 	VaultDetails
 	MongoClient MungoClient
@@ -109,4 +110,28 @@ func BuildCollections() map[string]string {
 	}
 
 	return col
+}
+
+// Deprecated: As of ConfigBuilder v0.5.0, RealMongoOperations.GetMongoClient
+func GetMongoClient(ctx context.Context, m Mongo) (*mongo.Client, error) {
+	if time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
+		mb, err := Build(m.VaultDetails, vaultHelper.NewVault(m.VaultDetails.Address, m.VaultDetails.Token))
+		if err != nil {
+			return nil, logs.Errorf("error building mongo: %v", err)
+		}
+		m = *mb
+	}
+
+	mm := RealMongoOperations{}
+	if _, err := mm.GetMongoClient(ctx, m); err != nil {
+		return nil, logs.Errorf("error getting mongo client: %v", err)
+	}
+	if _, err := mm.GetMongoDatabase(m); err != nil {
+		return nil, logs.Errorf("error getting mongo database: %v", err)
+	}
+	if _, err := mm.GetMongoCollection(m, m.Collection); err != nil {
+		return nil, logs.Errorf("error getting mongo collection: %v", err)
+	}
+
+	return mm.Client, nil
 }


### PR DESCRIPTION
The Mongo struct now includes a new field called "Collection" which allows specifying a single collection to use. The GetMongoClient function has been updated to handle this dynamic collection name by retrieving the collection from the Mongo struct before returning the client. This allows for more flexibility in working with different collections in the MongoDB database. Additionally, the deprecated comment has been added to indicate that the RealMongoOperations.GetMongoClient function is deprecated as of ConfigBuilder v0.5.0.