### PR TITLE
feat: add Disconnect method to MungoOperations interface and implement it in MockMongoOperations and RealMongoOperations

### DIFF
--- a/mongo/mongo_client.go
+++ b/mongo/mongo_client.go
@@ -23,6 +23,7 @@ type MungoOperations interface {
 	UpdateMany(ctx context.Context, filter interface{}, update interface{}) (*mongo.UpdateResult, error)
 	DeleteOne(ctx context.Context, filter interface{}) (*mongo.DeleteResult, error)
 	DeleteMany(ctx context.Context, filter interface{}) (*mongo.DeleteResult, error)
+	Disconnect(ctx context.Context) error
 }
 
 type RealMongoOperations struct {
@@ -73,6 +74,10 @@ func (r *RealMongoOperations) GetMongoCollection(m Mongo, collection string) (*m
 
 	r.Collection = r.Client.Database(m.Database).Collection(m.Collections[collection])
 	return r.Collection, nil
+}
+
+func (r *RealMongoOperations) Disconnect(ctx context.Context) error {
+	return r.Client.Disconnect(ctx)
 }
 
 func (r *RealMongoOperations) InsertOne(ctx context.Context, document interface{}) (*mongo.InsertOneResult, error) {

--- a/mongo/mongo_client_test.go
+++ b/mongo/mongo_client_test.go
@@ -54,6 +54,10 @@ func (mock *MockMongoOperations) GetMongoCollection(m Mongo, collection string) 
 	return mock.Collection, nil
 }
 
+func (mock *MockMongoOperations) Disconnect(ctx context.Context) error {
+	return nil
+}
+
 func (mock *MockMongoOperations) InsertOne(ctx context.Context, document interface{}) (*mongo.InsertOneResult, error) {
 	if ctx == nil {
 		ctx = context.Background()


### PR DESCRIPTION
The Disconnect method is added to the MungoOperations interface to provide a way to disconnect from the MongoDB server. The method is implemented in both the MockMongoOperations and RealMongoOperations structs. This allows for easier testing and better separation of concerns when working with MongoDB connections.