### PR TITLE
refactor: Update NewConfig to take VaultHelper by value

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,7 +15,8 @@ import (
 
 type Config struct {
 	VaultHelper *vaultHelper.VaultHelper
-	VaultPaths  vault.VaultPaths
+	VaultPaths  vault.Paths
+	VaultInject bool
 
 	Local    local.System
 	Vault    vault.System
@@ -48,12 +49,13 @@ func Local(cfg *Config) error {
 }
 
 func Vault(cfg *Config) error {
-	v, err := vault.Build()
+	v, vh, err := vault.Build()
 	if err != nil {
 		return logs.Errorf("build vault: %v", err)
 	}
 
 	cfg.Vault = *v
+	cfg.VaultHelper = &vh
 
 	return nil
 }
@@ -77,7 +79,7 @@ func Database(cfg *Config) error {
 func Mongo(cfg *Config) error {
 	m := mongo.NewSystem()
 	if cfg.VaultHelper != nil {
-    vd := mongo.VaultDetails{}
+		vd := mongo.VaultDetails{}
 		m.Setup(vd, *cfg.VaultHelper)
 	}
 	_, err := m.Build()
@@ -122,6 +124,7 @@ func Rabbit(cfg *Config) error {
 
 func Build(opts ...BuildOption) (*Config, error) {
 	cfg := &Config{}
+
 	if err := cfg.Build(opts...); err != nil {
 		return nil, logs.Errorf("build config: %v", err)
 	}

--- a/config.go
+++ b/config.go
@@ -30,9 +30,9 @@ type Config struct {
 
 type BuildOption func(*Config) error
 
-func NewConfig(vh *vaultHelper.VaultHelper) *Config {
+func NewConfig(vh vaultHelper.VaultHelper) *Config {
 	return &Config{
-		VaultHelper: vh,
+		VaultHelper: &vh,
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -40,6 +40,29 @@ func (m *MockVaultHelper) LeaseDuration() int {
 	return m.Lease
 }
 
+func TestConfig(t *testing.T) {
+  t.Run("test config mock vault", func(t *testing.T) {
+    mockVault := &MockVaultHelper{
+      KVSecrets: []vaulthelper.KVSecret{
+        {Key: "password", Value: "testPassword"},
+        {Key: "username", Value: "testUser"},
+        {Key: "rds-hostname", Value: "testHost"},
+        {Key: "rds-db", Value: "testDB"},
+      },
+    }
+
+    cfg := NewConfig(mockVault)
+    err := cfg.Build(Local)
+    assert.NoError(t, err)
+  })
+  t.Run("test config real vault", func(t *testing.T) {
+    vh := vaulthelper.NewVault("tester", "tester")
+    cfg := NewConfig(vh)
+    err := cfg.Build(Local)
+    assert.NoError(t, err)
+  })
+}
+
 func TestBuild(t *testing.T) {
 	t.Run("default values", func(t *testing.T) {
 		os.Clearenv() // Clear all environment variables

--- a/config_test.go
+++ b/config_test.go
@@ -41,26 +41,26 @@ func (m *MockVaultHelper) LeaseDuration() int {
 }
 
 func TestConfig(t *testing.T) {
-  t.Run("test config mock vault", func(t *testing.T) {
-    mockVault := &MockVaultHelper{
-      KVSecrets: []vaulthelper.KVSecret{
-        {Key: "password", Value: "testPassword"},
-        {Key: "username", Value: "testUser"},
-        {Key: "rds-hostname", Value: "testHost"},
-        {Key: "rds-db", Value: "testDB"},
-      },
-    }
+	t.Run("test config mock vault", func(t *testing.T) {
+		mockVault := &MockVaultHelper{
+			KVSecrets: []vaulthelper.KVSecret{
+				{Key: "password", Value: "testPassword"},
+				{Key: "username", Value: "testUser"},
+				{Key: "rds-hostname", Value: "testHost"},
+				{Key: "rds-db", Value: "testDB"},
+			},
+		}
 
-    cfg := NewConfig(mockVault)
-    err := cfg.Build(Local)
-    assert.NoError(t, err)
-  })
-  t.Run("test config real vault", func(t *testing.T) {
-    vh := vaulthelper.NewVault("tester", "tester")
-    cfg := NewConfig(vh)
-    err := cfg.Build(Local)
-    assert.NoError(t, err)
-  })
+		cfg := NewConfig(mockVault)
+		err := cfg.Build(Local)
+		assert.NoError(t, err)
+	})
+	t.Run("test config real vault", func(t *testing.T) {
+		vh := vaulthelper.NewVault("tester", "tester")
+		cfg := NewConfig(vh)
+		err := cfg.Build(Local)
+		assert.NoError(t, err)
+	})
 }
 
 func TestBuild(t *testing.T) {
@@ -161,7 +161,7 @@ func TestVault(t *testing.T) {
 		os.Clearenv()
 		cfg, err := Build(Vault)
 		assert.NoError(t, err)
-		assert.Equal(t, "localhost", cfg.Vault.Host)
+		assert.Equal(t, "vault.vault", cfg.Vault.Host)
 	})
 }
 

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	vaultHelper "github.com/keloran/vault-helper"
 	"strings"
 	"time"
 
@@ -10,40 +11,40 @@ import (
 	"github.com/caarlos0/env/v8"
 )
 
-type VaultPath struct {
-  Details     string
-  Credentials string
+type Path struct {
+	Details     string
+	Credentials string
 }
 
-type VaultPaths struct {
-  Database VaultPath
-  Keycloak VaultPath
-  Mongo    VaultPath
-  Rabbit   VaultPath
-  Influx   VaultPath
+type Paths struct {
+	Database Path
+	Keycloak Path
+	Mongo    Path
+	Rabbit   Path
+	Influx   Path
 }
 
 // System is the vault config
 type System struct {
-	Host       string `env:"VAULT_HOST" envDefault:"localhost"`
+	Host       string `env:"VAULT_HOST" envDefault:"vault.vault"`
 	Port       string `env:"VAULT_PORT" envDefault:""`
 	Token      string `env:"VAULT_TOKEN" envDefault:"root"`
 	Address    string
 	ExpireTime time.Time
 }
 
-func NewVault(address, token string) *System {
+func NewSystem(address, token string) *System {
 	return &System{
 		Address: address,
 		Token:   token,
 	}
 }
 
-func Build() (*System, error) {
-	v := NewVault("", "")
+func Build() (*System, vaultHelper.VaultHelper, error) {
+	v := NewSystem("", "")
 
 	if err := env.Parse(v); err != nil {
-		return v, logs.Errorf("vault: %v", err)
+		return v, nil, logs.Errorf("vault: %v", err)
 	}
 
 	if strings.HasPrefix(v.Host, "http") {
@@ -58,5 +59,7 @@ func Build() (*System, error) {
 		v.Address = fmt.Sprintf("https://%s", v.Host)
 	}
 
-	return v, nil
+	vh := vaultHelper.NewVault(v.Address, v.Token)
+
+	return v, vh, nil
 }

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -11,12 +11,12 @@ func TestBuild(t *testing.T) {
 	t.Run("default values", func(t *testing.T) {
 		os.Clearenv() // Clear all environment variables
 
-		l, err := Build()
+		l, _, err := Build()
 		assert.NoError(t, err)
-		assert.Equal(t, "localhost", l.Host)
+		assert.Equal(t, "vault.vault", l.Host)
 		assert.Equal(t, "", l.Port)
 		assert.Equal(t, "root", l.Token)
-		assert.Equal(t, "https://localhost", l.Address)
+		assert.Equal(t, "https://vault.vault", l.Address)
 	})
 
 	t.Run("with port", func(t *testing.T) {
@@ -25,9 +25,9 @@ func TestBuild(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		v, err := Build()
+		v, _, err := Build()
 		assert.NoError(t, err)
-		assert.Equal(t, "localhost:8080", v.Address)
+		assert.Equal(t, "vault.vault:8080", v.Address)
 	})
 
 	t.Run("with http prefix", func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestBuild(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		v, err := Build()
+		v, _, err := Build()
 		assert.NoError(t, err)
 		assert.Equal(t, "http://localhost", v.Address)
 	})


### PR DESCRIPTION
Updated the NewConfig function to take VaultHelper by value instead of by reference for consistency.