### PR TITLE
fix: Update error handling logic for keycloak host retrieval

### DIFF
--- a/keycloak/keycloak.go
+++ b/keycloak/keycloak.go
@@ -85,7 +85,7 @@ func (s *System) buildVault() (*Details, error) {
 
 	host, err := vh.GetSecret("keycloak-host")
 	if err != nil {
-		if err.Error() != fmt.Sprint("key not found: keycloak-host") {
+    if err.Error() != fmt.Sprint("key not found") && err.Error() != fmt.Sprint("key not found: keycloak-host") {
 			return key, logs.Errorf("failed to get host: %v", err)
 		}
 		host = "https://keys.chewedfeed.com"


### PR DESCRIPTION
Improve error handling logic by checking for both "key not found" and
"key not found: keycloak-host" errors when retrieving the keycloak host
from the secret manager. This ensures proper error handling and
prevents unnecessary error messages.