### PR TITLE
refactor: Replace influx username and password with token

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -193,8 +193,7 @@ func TestMongo(t *testing.T) {
 func TestInflux(t *testing.T) {
 	mockVault := &MockVaultHelper{
 		KVSecrets: []vaulthelper.KVSecret{
-			{Key: "influx-password", Value: "testPassword"},
-			{Key: "influx-username", Value: "testUser"},
+			{Key: "influx-token", Value: "testToken"},
 			{Key: "influx-hostname", Value: "testHost"},
 			{Key: "influx-db", Value: "testDB"},
 			{Key: "influx-org", Value: "testOrg"},
@@ -212,7 +211,7 @@ func TestInflux(t *testing.T) {
 		os.Clearenv()
 		cfg, err := BuildLocalVH(mockVault, Influx)
 		assert.NoError(t, err)
-		assert.Equal(t, "testUser", cfg.Influx.User)
+		assert.Equal(t, "testToken", cfg.Influx.Token)
 	})
 }
 

--- a/influx/influx.go
+++ b/influx/influx.go
@@ -15,8 +15,7 @@ type VaultDetails struct {
 
 type Details struct {
 	Host     string `env:"INFLUX_HOSTNAME" envDefault:"http://db.chewed-k8s.net:8086"`
-	User     string `env:"INFLUX_USERNAME"`
-	Password string `env:"INFLUX_PASSWORD"`
+	Token    string `env:"INFLUX_TOKEN"`
 	Bucket   string `env:"INFLUX_BUCKET"`
 	Org      string `env:"INFLUX_ORG"`
 }
@@ -71,17 +70,11 @@ func (s *System) buildVault() (*Details, error) {
 		return in, logs.Error("no influx cred serets found")
 	}
 
-	username, err := vh.GetSecret("influx-username")
+	token, err := vh.GetSecret("influx-token")
 	if err != nil {
-		return in, logs.Errorf("failed to get username: %v", err)
+		return in, logs.Errorf("failed to get token: %v", err)
 	}
-	in.User = username
-
-	password, err := vh.GetSecret("influx-password")
-	if err != nil {
-		return in, logs.Errorf("failed to get password: %v", err)
-	}
-	in.Password = password
+	in.Token = token
 
 	bucket, err := vh.GetSecret("influx-bucket")
 	if err != nil {

--- a/influx/influx_test.go
+++ b/influx/influx_test.go
@@ -44,10 +44,7 @@ func TestBuildGeneric(t *testing.T) {
 	if err := os.Setenv("INFLUX_HOSTNAME", "testHost"); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Setenv("INFLUX_USERNAME", "testUser"); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Setenv("INFLUX_PASSWORD", "testPassword"); err != nil {
+	if err := os.Setenv("INFLUX_TOKEN", "testToken"); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Setenv("INFLUX_BUCKET", "testBucket"); err != nil {
@@ -60,8 +57,7 @@ func TestBuildGeneric(t *testing.T) {
 	i := NewSystem()
 	in, err := i.Build()
 	assert.NoError(t, err)
-	assert.Equal(t, "testPassword", in.Password)
-	assert.Equal(t, "testUser", in.User)
+	assert.Equal(t, "testToken", in.Token)
 	assert.Equal(t, "testBucket", in.Bucket)
 	assert.Equal(t, "testOrg", in.Org)
 	assert.Equal(t, "testHost", in.Host)
@@ -70,8 +66,7 @@ func TestBuildGeneric(t *testing.T) {
 func TestBuildVault(t *testing.T) {
 	mockVault := &MockVaultHelper{
 		KVSecrets: []vaultHelper.KVSecret{
-			{Key: "influx-password", Value: "testPassword"},
-			{Key: "influx-username", Value: "testUser"},
+			{Key: "influx-token", Value: "testToken"},
 			{Key: "influx-bucket", Value: "testBucket"},
 			{Key: "influx-hostname", Value: "testHost"},
 			{Key: "influx-org", Value: "testOrg"},
@@ -86,8 +81,7 @@ func TestBuildVault(t *testing.T) {
 	in, err := i.Build()
 	assert.NoError(t, err)
 
-	assert.Equal(t, "testPassword", in.Password)
-	assert.Equal(t, "testUser", in.User)
+	assert.Equal(t, "testToken", in.Token)
 	assert.Equal(t, "testBucket", in.Bucket)
 	assert.Equal(t, "testOrg", in.Org)
 	assert.Equal(t, "testHost", in.Host)
@@ -96,8 +90,7 @@ func TestBuildVault(t *testing.T) {
 func TestBuildVaultNoHost(t *testing.T) {
 	mockVault := &MockVaultHelper{
 		KVSecrets: []vaultHelper.KVSecret{
-			{Key: "influx-password", Value: "testPassword"},
-			{Key: "influx-username", Value: "testUser"},
+			{Key: "influx-token", Value: "testToken"},
 			{Key: "influx-bucket", Value: "testBucket"},
 			{Key: "influx-org", Value: "testOrg"},
 		},
@@ -111,8 +104,7 @@ func TestBuildVaultNoHost(t *testing.T) {
 	in, err := i.Build()
 	assert.NoError(t, err)
 
-	assert.Equal(t, "testPassword", in.Password)
-	assert.Equal(t, "testUser", in.User)
+	assert.Equal(t, "testToken", in.Token)
 	assert.Equal(t, "testBucket", in.Bucket)
 	assert.Equal(t, "testOrg", in.Org)
 	assert.Equal(t, "http://db.chewed-k8s.net:8086", in.Host)


### PR DESCRIPTION
Replaced the influx username and password with token for better security and
authentication. Also updated related tests and configurations.