### PR TITLE
refactor: Update package names in tests

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
@@ -9,38 +8,8 @@ import (
 	vaultHelper "github.com/keloran/vault-helper"
 )
 
-type MockVaultHelper struct {
-	KVSecrets []vaultHelper.KVSecret
-	Lease     int
-}
-
-func (m *MockVaultHelper) GetSecrets(path string) error {
-	if path == "" {
-		return fmt.Errorf("path not found: %s", path)
-	}
-
-	return nil // or simulate an error if needed
-}
-
-func (m *MockVaultHelper) GetSecret(key string) (string, error) {
-	for _, s := range m.Secrets() {
-		if s.Key == key {
-			return s.Value, nil
-		}
-	}
-  return "", fmt.Errorf("key: '%s' not found", key)
-}
-
-func (m *MockVaultHelper) Secrets() []vaultHelper.KVSecret {
-	return m.KVSecrets
-}
-
-func (m *MockVaultHelper) LeaseDuration() int {
-	return m.Lease
-}
-
 func TestBuildVault(t *testing.T) {
-	mockVault := &MockVaultHelper{
+	mockVault := &vaultHelper.MockVaultHelper{
 		KVSecrets: []vaultHelper.KVSecret{
 			{Key: "password", Value: "testPassword"},
 			{Key: "username", Value: "testUser"},
@@ -67,7 +36,7 @@ func TestBuildVault(t *testing.T) {
 }
 
 func TestBuildVaultNoPort(t *testing.T) {
-	mockVault := &MockVaultHelper{
+	mockVault := &vaultHelper.MockVaultHelper{
 		KVSecrets: []vaultHelper.KVSecret{
 			{Key: "password", Value: "testPassword"},
 			{Key: "username", Value: "testUser"},

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Nerzal/gocloak/v13 v13.9.0
 	github.com/bugfixes/go-bugfixes v0.12.2
 	github.com/caarlos0/env/v8 v8.0.0
-	github.com/keloran/vault-helper v0.8.2
+	github.com/keloran/vault-helper v0.9.0
 	github.com/stretchr/testify v1.9.0
 	go.mongodb.org/mongo-driver v1.15.0
 	go.uber.org/mock v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/keloran/vault-helper v0.8.2 h1:Nmsb3XAhuaLQRv+LirOTSjdv6WcJuqNK+7xnOLAa+ME=
 github.com/keloran/vault-helper v0.8.2/go.mod h1:JZ/puuBd4+dWYZOeVEA7SgzbQS2VyYJibWte6q1h8Mk=
+github.com/keloran/vault-helper v0.9.0 h1:ZFAtqRVDoWwgxx+LLo7G4uzKdu77dv+gx/VoNGjS7qo=
+github.com/keloran/vault-helper v0.9.0/go.mod h1:7RVafZ/PkD7NBoTMtHx/jsEh9l7JRZ42oE2XkrSnKSo=
 github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
 github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/influx/influx_test.go
+++ b/influx/influx_test.go
@@ -1,42 +1,11 @@
 package influx
 
 import (
-	"fmt"
 	vaultHelper "github.com/keloran/vault-helper"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 )
-
-type MockVaultHelper struct {
-	KVSecrets []vaultHelper.KVSecret
-	Lease     int
-}
-
-func (m *MockVaultHelper) GetSecrets(path string) error {
-	if path == "" {
-		return fmt.Errorf("path not found: %s", path)
-	}
-
-	return nil // or simulate an error if needed
-}
-
-func (m *MockVaultHelper) GetSecret(key string) (string, error) {
-	for _, s := range m.Secrets() {
-		if s.Key == key {
-			return s.Value, nil
-		}
-	}
-  return "", fmt.Errorf("key: '%s' not found", key)
-}
-
-func (m *MockVaultHelper) Secrets() []vaultHelper.KVSecret {
-	return m.KVSecrets
-}
-
-func (m *MockVaultHelper) LeaseDuration() int {
-	return m.Lease
-}
 
 func TestBuildGeneric(t *testing.T) {
 	os.Clearenv()
@@ -64,7 +33,7 @@ func TestBuildGeneric(t *testing.T) {
 }
 
 func TestBuildVault(t *testing.T) {
-	mockVault := &MockVaultHelper{
+	mockVault := &vaultHelper.MockVaultHelper{
 		KVSecrets: []vaultHelper.KVSecret{
 			{Key: "influx-token", Value: "testToken"},
 			{Key: "influx-bucket", Value: "testBucket"},
@@ -88,7 +57,7 @@ func TestBuildVault(t *testing.T) {
 }
 
 func TestBuildVaultNoHost(t *testing.T) {
-	mockVault := &MockVaultHelper{
+	mockVault := &vaultHelper.MockVaultHelper{
 		KVSecrets: []vaultHelper.KVSecret{
 			{Key: "influx-token", Value: "testToken"},
 			{Key: "influx-bucket", Value: "testBucket"},

--- a/keycloak/keycloak_test.go
+++ b/keycloak/keycloak_test.go
@@ -1,47 +1,16 @@
 package keycloak
 
 import (
-	"fmt"
-	vaulthelper "github.com/keloran/vault-helper"
+	vaultHelper "github.com/keloran/vault-helper"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-type MockVaultHelper struct {
-	KVSecrets []vaulthelper.KVSecret
-	Lease     int
-}
-
-func (m *MockVaultHelper) GetSecrets(path string) error {
-	if path == "" {
-		return fmt.Errorf("path not found: %s", path)
-	}
-
-	return nil
-}
-
-func (m *MockVaultHelper) GetSecret(key string) (string, error) {
-	for _, s := range m.Secrets() {
-		for s.Key == key {
-			return s.Value, nil
-		}
-	}
-
-	return "", fmt.Errorf("key: '%s' not found", key)
-}
-
-func (m *MockVaultHelper) Secrets() []vaulthelper.KVSecret {
-	return m.KVSecrets
-}
-func (m *MockVaultHelper) LeaseDuration() int {
-	return m.Lease
-}
-
 func TestBuildVault(t *testing.T) {
-	mockVault := &MockVaultHelper{
-		KVSecrets: []vaulthelper.KVSecret{
+	mockVault := &vaultHelper.MockVaultHelper{
+		KVSecrets: []vaultHelper.KVSecret{
 			{Key: "keycloak-client", Value: "testClient"},
 			{Key: "keycloak-secret", Value: "testSecret"},
 			{Key: "keycloak-realm", Value: "testRealm"},

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -1,45 +1,11 @@
 package mongo
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
-	"github.com/bugfixes/go-bugfixes/logs"
-
-	vaultHelper "github.com/keloran/vault-helper"
 	"github.com/stretchr/testify/assert"
 )
-
-type MockVaultHelper struct {
-	KVSecrets []vaultHelper.KVSecret
-	Lease     int
-}
-
-func (m *MockVaultHelper) GetSecrets(path string) error {
-	if path == "" {
-		return logs.Error("path not found")
-	}
-
-	return nil // or simulate an error if needed
-}
-
-func (m *MockVaultHelper) GetSecret(key string) (string, error) {
-	for _, s := range m.Secrets() {
-		if s.Key == key {
-			return s.Value, nil
-		}
-	}
-  return "", fmt.Errorf("key: '%s' not found", key)
-}
-
-func (m *MockVaultHelper) Secrets() []vaultHelper.KVSecret {
-	return m.KVSecrets
-}
-
-func (m *MockVaultHelper) LeaseDuration() int {
-	return m.Lease
-}
 
 func TestBuildCollections(t *testing.T) {
 	os.Clearenv() // Clear all environment variables

--- a/rabbit/rabbit_test.go
+++ b/rabbit/rabbit_test.go
@@ -1,6 +1,9 @@
 package rabbit
 
 import (
+	"bytes"
+	"io"
+	"net/http"
 	"os"
 	"testing"
 
@@ -9,22 +12,23 @@ import (
 )
 
 type MockHTTPClient struct{}
+
 func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-  if req.URL.Path == "testHost/api/queues/testVHost/testQueue/get" {
-    response := `[
+	if req.URL.Path == "testHost/api/queues/testVHost/testQueue/get" {
+		response := `[
       {"payload":"test message","payload_bytes":12,"redelivered":false}
     ]`
-    return &http.Response{
-      StatusCode: 200,
-      Body:       io.NopCloser(bytes.NewBufferString(response)),
-      Header:     make(http.Header),
-    }, nil
-  }
-  return &http.Response{
-    StatusCode: 404,
-    Body:       io.NopCloser(bytes.NewBufferString("")),
-    Header:     make(http.Header),
-  }, nil
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(bytes.NewBufferString(response)),
+			Header:     make(http.Header),
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: 404,
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+		Header:     make(http.Header),
+	}, nil
 }
 
 func TestVaultBuild(t *testing.T) {

--- a/rabbit/rabbit_test.go
+++ b/rabbit/rabbit_test.go
@@ -1,67 +1,35 @@
 package rabbit
 
 import (
-	"bytes"
-	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"testing"
 
-	vaulthelper "github.com/keloran/vault-helper"
+	vaultHelper "github.com/keloran/vault-helper"
 	"github.com/stretchr/testify/assert"
 )
 
 type MockHTTPClient struct{}
-
 func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	if req.URL.Path == "testHost/api/queues/testVHost/testQueue/get" {
-		response := `[
-			{"payload":"test message","payload_bytes":12,"redelivered":false}
-		]`
-		return &http.Response{
-			StatusCode: 200,
-			Body:       io.NopCloser(bytes.NewBufferString(response)),
-			Header:     make(http.Header),
-		}, nil
-	}
-	return &http.Response{
-		StatusCode: 404,
-		Body:       io.NopCloser(bytes.NewBufferString("")),
-		Header:     make(http.Header),
-	}, nil
-}
-
-type MockVaultHelper struct {
-	KVSecrets []vaulthelper.KVSecret
-	Lease     int
-}
-
-func (m *MockVaultHelper) GetSecrets(path string) error {
-	if path == "" {
-		return nil
-	}
-
-	return nil // or simulate an error if needed
-}
-func (m *MockVaultHelper) GetSecret(key string) (string, error) {
-	for _, s := range m.Secrets() {
-		if s.Key == key {
-			return s.Value, nil
-		}
-	}
-  return "", fmt.Errorf("key: '%s' not found", key)
-}
-func (m *MockVaultHelper) Secrets() []vaulthelper.KVSecret {
-	return m.KVSecrets
-}
-func (m *MockVaultHelper) LeaseDuration() int {
-	return m.Lease
+  if req.URL.Path == "testHost/api/queues/testVHost/testQueue/get" {
+    response := `[
+      {"payload":"test message","payload_bytes":12,"redelivered":false}
+    ]`
+    return &http.Response{
+      StatusCode: 200,
+      Body:       io.NopCloser(bytes.NewBufferString(response)),
+      Header:     make(http.Header),
+    }, nil
+  }
+  return &http.Response{
+    StatusCode: 404,
+    Body:       io.NopCloser(bytes.NewBufferString("")),
+    Header:     make(http.Header),
+  }, nil
 }
 
 func TestVaultBuild(t *testing.T) {
-	mockVault := &MockVaultHelper{
-		KVSecrets: []vaulthelper.KVSecret{
+	mockVault := &vaultHelper.MockVaultHelper{
+		KVSecrets: []vaultHelper.KVSecret{
 			{Key: "rabbit-hostname", Value: "testHost"},
 			{Key: "rabbit-management-hostname", Value: "testManagementHost"},
 			{Key: "rabbit-username", Value: "testUsername"},
@@ -112,8 +80,8 @@ func TestGenericBuild(t *testing.T) {
 }
 
 func TestGetRabbitQueue(t *testing.T) {
-	mockVault := &MockVaultHelper{
-		KVSecrets: []vaulthelper.KVSecret{
+	mockVault := &vaultHelper.MockVaultHelper{
+		KVSecrets: []vaultHelper.KVSecret{
 			{Key: "rabbit-hostname", Value: "testHost"},
 			{Key: "rabbit-management-hostname", Value: "testManagementHost"},
 			{Key: "rabbit-username", Value: "testUsername"},


### PR DESCRIPTION
Update package names in rabbit, mongo, and keycloak tests to match changes
in the package structure. Fix import paths and struct names.