### PR TITLE
fix: Correct method receiver names in keycloak and database packages

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -277,7 +277,7 @@ func TestProjectBuild(t *testing.T) {
 		os.Clearenv()
 
 		cfgNoProps, _ := Build(Local)
-		assert.Equal(t, map[string]interface{}(map[string]interface{}(nil)), cfgNoProps.ProjectProperties)
+		assert.Equal(t, map[string]interface{}(nil), cfgNoProps.ProjectProperties)
 
 		cfg, err := Build(Local, WithProjectConfigurator(MockProjectConfigurator{}))
 		assert.NoError(t, err)

--- a/database/database.go
+++ b/database/database.go
@@ -136,7 +136,10 @@ func (s *System) buildVault() (*Details, error) {
 
 func (s *System) GetPGXClient(ctx context.Context) (*pgx.Conn, error) {
 	if time.Now().Unix() > s.VaultDetails.ExpireTime.Unix() {
-		s.buildVault()
+		_, err := s.buildVault()
+    if err != nil {
+      return nil, logs.Errorf("failed to build vault: %v", err)
+    }
 	}
 
 	client, err := pgx.Connect(ctx, fmt.Sprintf("postgres://%s:%s@%s:%d/%s", s.User, s.Password, s.Host, s.Port, s.DBName))

--- a/keycloak/keycloak.go
+++ b/keycloak/keycloak.go
@@ -107,8 +107,8 @@ func (s *System) buildGeneric() (*Details, error) {
 }
 
 func (s *System) GetClient(ctx context.Context) (*gocloak.GoCloak, *gocloak.JWT, error) {
-	client := gocloak.NewClient(k.Host)
-	token, err := client.LoginClient(ctx, k.Client, k.Secret, k.Realm)
+	client := gocloak.NewClient(s.Host)
+	token, err := client.LoginClient(ctx, s.Client, s.Secret, s.Realm)
 	if err != nil {
 		return nil, nil, logs.Errorf("failed to login client: %v", err)
 	}

--- a/keycloak/keycloak.go
+++ b/keycloak/keycloak.go
@@ -106,7 +106,7 @@ func (s *System) buildGeneric() (*Details, error) {
 	return key, nil
 }
 
-func (k *System) GetClient(ctx context.Context) (*gocloak.GoCloak, *gocloak.JWT, error) {
+func (s *System) GetClient(ctx context.Context) (*gocloak.GoCloak, *gocloak.JWT, error) {
 	client := gocloak.NewClient(k.Host)
 	token, err := client.LoginClient(ctx, k.Client, k.Secret, k.Realm)
 	if err != nil {


### PR DESCRIPTION
Properly rename method receiver names in keycloak and database packages for consistency. Additionally, handle error case in GetPGXClient method to log failure in building vault. Update test case in config_test.go to remove redundant type casting.