### PR TITLE
feat(tests): enhance Keycloak container setup with timeout

### DIFF
--- a/auth/keycloak/keycloak_test.go
+++ b/auth/keycloak/keycloak_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"os"
 	"testing"
+	"time"
 
 	key "github.com/stillya/testcontainers-keycloak"
 	"github.com/stretchr/testify/assert"
@@ -76,9 +77,12 @@ func TestBuildGeneric(t *testing.T) {
 func setupKeycloak(ctx context.Context) (*key.KeycloakContainer, error) {
 	kc, err := key.Run(ctx,
 		fmt.Sprintf("keycloak/keycloak:%s", keycloakVersion),
-		testcontainers.WithWaitStrategy(wait.ForListeningPort("8080/tcp")),
+
+		testcontainers.WithWaitStrategy(
+			wait.ForListeningPort("8080/tcp"),
+			wait.ForLog("[org.keycloak.quarkus.runtime.KeycloakMain] (main) Running the server in development mode. DO NOT use this configuration in production.").WithStartupTimeout(1*time.Minute),
+		),
 		key.WithContextPath("/auth"),
-		//key.WithRealmImportFile("../testdata/realm-export.json"),
 		key.WithAdminUsername(adminUser),
 		key.WithAdminPassword(adminPassword),
 	)


### PR DESCRIPTION
Add a startup timeout to the Keycloak container setup in tests. This 
ensures that the test waits for both the listening port and the 
specific message indicating that the server