### PR TITLE
fix: update dependencies and improve vault checks

### DIFF
--- a/database/mongo/mongo_real_client.go
+++ b/database/mongo/mongo_real_client.go
@@ -17,7 +17,7 @@ type RealMongoOperations struct {
 }
 
 func (r *RealMongoOperations) GetMongoClient(ctx context.Context, m System) (*mongo.Client, error) {
-	if time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
+	if m.VaultHelper != nil && time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
 		mr := NewSystem()
 		mr.Setup(m.VaultDetails, *mr.VaultHelper)
 		_, err := mr.Build()
@@ -37,7 +37,7 @@ func (r *RealMongoOperations) GetMongoClient(ctx context.Context, m System) (*mo
 }
 
 func (r *RealMongoOperations) GetMongoDatabase(m System) (*mongo.Database, error) {
-	if time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
+	if m.VaultHelper != nil && time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
 		mr := NewSystem()
 		mr.Setup(m.VaultDetails, *mr.VaultHelper)
 		_, err := mr.Build()
@@ -52,7 +52,7 @@ func (r *RealMongoOperations) GetMongoDatabase(m System) (*mongo.Database, error
 }
 
 func (r *RealMongoOperations) GetMongoCollection(m System, collection string) (*mongo.Collection, error) {
-	if time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
+	if m.VaultHelper != nil && time.Now().Unix() > m.VaultDetails.ExpireTime.Unix() {
 		mr := NewSystem()
 		mr.Setup(m.VaultDetails, *mr.VaultHelper)
 		_, err := mr.Build()

--- a/database/mongo/mongo_test.go
+++ b/database/mongo/mongo_test.go
@@ -1,11 +1,32 @@
 package mongo
 
 import (
+	"context"
+	"fmt"
+	"github.com/testcontainers/testcontainers-go"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/testcontainers/testcontainers-go/modules/mongodb"
 )
+
+func setupMongo(ctx context.Context) (*mongodb.MongoDBContainer, error) {
+	mc, err := mongodb.Run(ctx, "mongo:latest")
+	if err != nil {
+		return nil, fmt.Errorf("failed to start mongo: %v", err)
+	}
+
+	return mc, nil
+}
+
+func shutdownMongo(ctx context.Context, mc *mongodb.MongoDBContainer) error {
+	if err := testcontainers.TerminateContainer(mc); err != nil {
+		return fmt.Errorf("failed to terminate container: %v", err)
+	}
+
+	return nil
+}
 
 func TestBuildCollections(t *testing.T) {
 	os.Clearenv() // Clear all environment variables

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/keloran/vault-helper v1.1.0
 	github.com/stillya/testcontainers-keycloak v0.3.1
 	github.com/stretchr/testify v1.10.0
-	github.com/testcontainers/testcontainers-go v0.33.0
+	github.com/testcontainers/testcontainers-go v0.34.0
 	go.mongodb.org/mongo-driver v1.17.1
 	go.uber.org/mock v0.5.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/containerd/containerd v1.7.18 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
-	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.1.1+incompatible // indirect
@@ -79,6 +79,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/testcontainers/testcontainers-go/modules/mongodb v0.34.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpS
 github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
+github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -176,6 +178,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/testcontainers/testcontainers-go v0.33.0 h1:zJS9PfXYT5O0ZFXM2xxXfk4J5UMw/kRiISng037Gxdw=
 github.com/testcontainers/testcontainers-go v0.33.0/go.mod h1:W80YpTa8D5C3Yy16icheD01UTDu+LmXIA2Keo+jWtT8=
+github.com/testcontainers/testcontainers-go v0.34.0 h1:5fbgF0vIN5u+nD3IWabQwRybuB4GY8G2HHgCkbMzMHo=
+github.com/testcontainers/testcontainers-go v0.34.0/go.mod h1:6P/kMkQe8yqPHfPWNulFGdFHTD8HB2vLq/231xY2iPQ=
+github.com/testcontainers/testcontainers-go/modules/mongodb v0.34.0 h1:o3bgcECyBFfMwqexCH/6vIJ8XzbCffCP/Euesu33rgY=
+github.com/testcontainers/testcontainers-go/modules/mongodb v0.34.0/go.mod h1:ljLR42dN7k40CX0dp30R8BRIB3OOdvr7rBANEpfmMs4=
 github.com/testcontainers/testcontainers-go/modules/vault v0.31.0 h1:UYUDPWdAaea6X/c24wDCerEj8LmIITotBn6B+hKCOsU=
 github.com/testcontainers/testcontainers-go/modules/vault v0.31.0/go.mod h1:pgbNbHxWkql7ctY/Vc5KA1f+b1jtMj6L9/fDc2LPpIA=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=

--- a/rabbit/rabbit.go
+++ b/rabbit/rabbit.go
@@ -135,7 +135,7 @@ func (s *System) buildVault() (*Details, error) {
 }
 
 func (s *System) GetRabbitQueue() (interface{}, error) {
-	if time.Now().Unix() > s.VaultDetails.ExpireTime.Unix() {
+	if s.VaultHelper != nil && time.Now().Unix() > s.VaultDetails.ExpireTime.Unix() {
 		_, err := s.Build()
 		if err != nil {
 			return nil, logs.Errorf("rabbit: unable to build rabbit: %v", err)


### PR DESCRIPTION
Update the `testcontainers-go` dependency to version 0.34.0 and 
the `dockercfg` dependency to version 0.3.2. Enhance vault 
expiration checks in the `GetMongoCollection` and `GetRabbitQueue` 
methods to ensure `VaultHelper` is not nil before checking 
expiration. Add setup and teardown functions for MongoDB 
containers in tests to improve test reliability.