### PR TITLE
fix: correct environment variable name for bugfixes

### DIFF
--- a/auth/clerk/clerk_test.go
+++ b/auth/clerk/clerk_test.go
@@ -1,0 +1,63 @@
+package clerk
+
+import (
+	vaultHelper "github.com/keloran/vault-helper"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestBuildGeneric(t *testing.T) {
+	os.Clearenv()
+
+	if err := os.Setenv("CLERK_SECRET_KEY", "testKey"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "testPublicKey"); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewSystem()
+	ck, err := c.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, "testKey", ck.Key)
+	assert.Equal(t, "testPublicKey", ck.PublicKey)
+}
+
+func TestBuildVault(t *testing.T) {
+	mockVault := &vaultHelper.MockVaultHelper{
+		KVSecrets: []vaultHelper.KVSecret{
+			{Key: "clerk_key", Value: "testKey"},
+			{Key: "clerk_public_key", Value: "testPublicKey"},
+		},
+	}
+
+	vd := &vaultHelper.VaultDetails{
+		DetailsPath: "tester",
+	}
+	c := NewSystem()
+	c.Setup(*vd, mockVault)
+	ck, err := c.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, "testKey", ck.Key)
+	assert.Equal(t, "testPublicKey", ck.PublicKey)
+}
+
+func TestBuildVaultNoKey(t *testing.T) {
+	mockVault := &vaultHelper.MockVaultHelper{
+		KVSecrets: []vaultHelper.KVSecret{
+			{Key: "clerk_key", Value: "testKey"},
+			{Key: "clerk_public_key", Value: "testPublicKey"},
+		},
+	}
+
+	vd := &vaultHelper.VaultDetails{
+		DetailsPath: "tester",
+	}
+	c := NewSystem()
+	c.Setup(*vd, mockVault)
+	ck, err := c.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, "testKey", ck.Key)
+	assert.Equal(t, "testPublicKey", ck.PublicKey)
+}

--- a/bugfixes/bugfixes.go
+++ b/bugfixes/bugfixes.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Details struct {
-	Server      string `env:"BUGIXES_SERVER" envDefault:"https://api.bugfix.es/v1"`
+	Server      string `env:"BUGFIXES_SERVER" envDefault:"https://api.bugfix.es/v1"`
 	AgentKey    string `env:"BUGFIXES_AGENT_KEY"`
 	AgentSecret string `env:"BUGFIXES_AGENT_SECRET"`
 }

--- a/bugfixes/bugfixes_test.go
+++ b/bugfixes/bugfixes_test.go
@@ -17,7 +17,7 @@ func TestBuildGeneric(t *testing.T) {
 	if err := os.Setenv("BUGFIXES_AGENT_SECRET", "testSecret"); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Setenv("BUGIXES_SERVER", "http://bob.bob"); err != nil {
+	if err := os.Setenv("BUGFIXES_SERVER", "http://bob.bob"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -252,6 +252,52 @@ func TestBugfixes(t *testing.T) {
 	assert.Equal(t, "testSecret", cfg.Bugfixes.Logger.Secret)
 }
 
+func TestClerk(t *testing.T) {
+	t.Run("clerk no set values", func(t *testing.T) {
+		os.Clearenv()
+
+		cfg, err := BuildLocal(Clerk)
+		assert.NoError(t, err)
+		assert.Equal(t, "", cfg.Clerk.PublicKey)
+	})
+	t.Run("clerk with values", func(t *testing.T) {
+		mockVault := &MockVaultHelper{
+			KVSecrets: []vaulthelper.KVSecret{
+				{Key: "clerk_key", Value: "testKey"},
+				{Key: "clerk_public_key", Value: "testPublicKey"},
+			},
+		}
+
+		os.Clearenv()
+		cfg, err := BuildLocalVH(mockVault, Clerk)
+		assert.NoError(t, err)
+		assert.Equal(t, "testPublicKey", cfg.Clerk.PublicKey)
+		assert.Equal(t, "testKey", cfg.Clerk.Key)
+	})
+}
+
+func TestResend(t *testing.T) {
+	t.Run("resend no set values", func(t *testing.T) {
+		os.Clearenv()
+
+		cfg, err := BuildLocal(Resend)
+		assert.NoError(t, err)
+		assert.Equal(t, "", cfg.Resend.Key)
+	})
+	t.Run("resend with values", func(t *testing.T) {
+		mockVault := &MockVaultHelper{
+			KVSecrets: []vaulthelper.KVSecret{
+				{Key: "resend_key", Value: "testKey"},
+			},
+		}
+
+		os.Clearenv()
+		cfg, err := BuildLocalVH(mockVault, Resend)
+		assert.NoError(t, err)
+		assert.Equal(t, "testKey", cfg.Resend.Key)
+	})
+}
+
 // Assuming ProjectConfigurator interface and Config structure are defined as shown previously
 
 // MockProjectConfigurator is a mock implementation for testing purposes.

--- a/notify/resend/resend.go
+++ b/notify/resend/resend.go
@@ -1,4 +1,4 @@
-package clerk
+package resend
 
 import (
 	"context"
@@ -7,8 +7,7 @@ import (
 )
 
 type Details struct {
-	Key       string `env:"CLERK_SECRET_KEY" envDefault:""`
-	PublicKey string `env:"NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" envDefault:""`
+	Key string `env:"RESEND_KEY" envDefault:""`
 }
 
 type System struct {
@@ -55,32 +54,24 @@ func (s *System) buildGeneric() (*Details, error) {
 }
 
 func (s *System) buildVault() (*Details, error) {
-	clerk := &Details{}
+	resend := &Details{}
 	vh := *s.VaultHelper
 
 	if err := vh.GetSecrets(s.VaultDetails.DetailsPath); err != nil {
-		return clerk, err
+		return resend, err
 	}
 	if vh.Secrets() == nil {
-		return clerk, nil
+		return resend, nil
 	}
 
-	if clerk.Key == "" {
-		secret, err := vh.GetSecret("clerk_key")
+	if resend.Key == "" {
+		secret, err := vh.GetSecret("resend_key")
 		if err != nil {
-			return clerk, err
+			return resend, err
 		}
-		clerk.Key = secret
+		resend.Key = secret
 	}
 
-	if clerk.PublicKey == "" {
-		secret, err := vh.GetSecret("clerk_public_key")
-		if err != nil {
-			return clerk, err
-		}
-		clerk.PublicKey = secret
-	}
-
-	s.Details = *clerk
-	return clerk, nil
+	s.Details = *resend
+	return resend, nil
 }

--- a/notify/resend/resend_test.go
+++ b/notify/resend/resend_test.go
@@ -1,0 +1,55 @@
+package resend
+
+import (
+	vaultHelper "github.com/keloran/vault-helper"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestBuildGeneric(t *testing.T) {
+	os.Clearenv()
+
+	if err := os.Setenv("RESEND_KEY", "testKey"); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewSystem()
+	rd, err := r.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, "testKey", rd.Key)
+}
+
+func TestBuildVault(t *testing.T) {
+	mockVault := &vaultHelper.MockVaultHelper{
+		KVSecrets: []vaultHelper.KVSecret{
+			{Key: "resend_key", Value: "testKey"},
+		},
+	}
+
+	vd := &vaultHelper.VaultDetails{
+		DetailsPath: "tester",
+	}
+	r := NewSystem()
+	r.Setup(*vd, mockVault)
+	rd, err := r.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, "testKey", rd.Key)
+}
+
+func TestBuildVaultNoKey(t *testing.T) {
+	mockVault := &vaultHelper.MockVaultHelper{
+		KVSecrets: []vaultHelper.KVSecret{
+			{Key: "resend_key", Value: "testKey"},
+		},
+	}
+
+	vd := &vaultHelper.VaultDetails{
+		DetailsPath: "tester",
+	}
+	r := NewSystem()
+	r.Setup(*vd, mockVault)
+	rd, err := r.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, "testKey", rd.Key)
+}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -18,13 +18,14 @@ type Path struct {
 }
 
 type Paths struct {
-	Database  Path
-	Keycloak  Path
-	Mongo     Path
-	Rabbit    Path
-	Influx    Path
-	BugFixes  Path
-	Authentik Path
+	Database Path
+	Keycloak Path
+	Mongo    Path
+	Rabbit   Path
+	Influx   Path
+	BugFixes Path
+	Clerk    Path
+	Resend   Path
 }
 
 // System is the vault config


### PR DESCRIPTION
Fixes the environment variable name from `BUGIXES_SERVER` to 
`BUGFIXES_SERVER` in the bugfixes package. Adds a new resend 
package that includes functionality for building details from 
environment variables and a vault. Implements tests for both 
the clerk and resend packages to ensure correct behavior.