### PR TITLE
feat: add test for BuildVault with missing public key

### DIFF
--- a/auth/clerk/clerk.go
+++ b/auth/clerk/clerk.go
@@ -2,6 +2,7 @@ package clerk
 
 import (
 	"context"
+	"fmt"
 	"github.com/caarlos0/env/v8"
 	vaultHelper "github.com/keloran/vault-helper"
 )
@@ -76,7 +77,9 @@ func (s *System) buildVault() (*Details, error) {
 	if clerk.PublicKey == "" {
 		secret, err := vh.GetSecret("clerk_public_key")
 		if err != nil {
-			return clerk, err
+			if err.Error() != fmt.Sprint("key: 'clerk_public_key' not found") {
+				return clerk, err
+			}
 		}
 		clerk.PublicKey = secret
 	}

--- a/auth/clerk/clerk_test.go
+++ b/auth/clerk/clerk_test.go
@@ -61,3 +61,21 @@ func TestBuildVaultNoKey(t *testing.T) {
 	assert.Equal(t, "testKey", ck.Key)
 	assert.Equal(t, "testPublicKey", ck.PublicKey)
 }
+
+func TestBuildVaultNoPublicKey(t *testing.T) {
+	mockVault := &vaultHelper.MockVaultHelper{
+		KVSecrets: []vaultHelper.KVSecret{
+			{Key: "clerk_key", Value: "testKey"},
+		},
+	}
+
+	vd := &vaultHelper.VaultDetails{
+		DetailsPath: "tester",
+	}
+	c := NewSystem()
+	c.Setup(*vd, mockVault)
+	ck, err := c.Build()
+	assert.NoError(t, err)
+	assert.Equal(t, "testKey", ck.Key)
+	assert.Equal(t, "", ck.PublicKey)
+}


### PR DESCRIPTION
Adds a new test case to verify the behavior of the BuildVault method 
when the public key is not provided. Updates the error handling in 
the buildVault function to only return an error for specific cases, 
ensuring that the absence of the public key does not cause a failure.