### PR TITLE
feat(auth/clerk): Update Clerk secret key names

### DIFF
--- a/auth/clerk/clerk.go
+++ b/auth/clerk/clerk.go
@@ -67,7 +67,7 @@ func (s *System) buildVault() (*Details, error) {
 	}
 
 	if s.Details.Key == "" {
-		secret, err := vh.GetSecret("clerk_key")
+		secret, err := vh.GetSecret("clerk-key")
 		if err != nil {
 			return clerk, err
 		}
@@ -77,9 +77,9 @@ func (s *System) buildVault() (*Details, error) {
 	}
 
 	if s.Details.PublicKey == "" {
-		secret, err := vh.GetSecret("clerk_public_key")
+		secret, err := vh.GetSecret("clerk-public-key")
 		if err != nil {
-			if err.Error() != fmt.Sprint("key: 'clerk_public_key' not found") {
+			if err.Error() != fmt.Sprint("key: 'clerk-public-key' not found") {
 				return clerk, err
 			}
 		}

--- a/auth/clerk/clerk_test.go
+++ b/auth/clerk/clerk_test.go
@@ -27,8 +27,8 @@ func TestBuildGeneric(t *testing.T) {
 func TestBuildVault(t *testing.T) {
 	mockVault := &vaultHelper.MockVaultHelper{
 		KVSecrets: []vaultHelper.KVSecret{
-			{Key: "clerk_key", Value: "testKey"},
-			{Key: "clerk_public_key", Value: "testPublicKey"},
+			{Key: "clerk-key", Value: "testKey"},
+			{Key: "clerk-public-key", Value: "testPublicKey"},
 		},
 	}
 
@@ -46,8 +46,8 @@ func TestBuildVault(t *testing.T) {
 func TestBuildVaultNoKey(t *testing.T) {
 	mockVault := &vaultHelper.MockVaultHelper{
 		KVSecrets: []vaultHelper.KVSecret{
-			{Key: "clerk_key", Value: "testKey"},
-			{Key: "clerk_public_key", Value: "testPublicKey"},
+			{Key: "clerk-key", Value: "testKey"},
+			{Key: "clerk-public-key", Value: "testPublicKey"},
 		},
 	}
 
@@ -66,7 +66,7 @@ func TestBuildVaultNoPublicKey(t *testing.T) {
 	os.Clearenv()
 	mockVault := &vaultHelper.MockVaultHelper{
 		KVSecrets: []vaultHelper.KVSecret{
-			{Key: "clerk_key", Value: "testKey"},
+			{Key: "clerk-key", Value: "testKey"},
 		},
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -263,8 +263,8 @@ func TestClerk(t *testing.T) {
 	t.Run("clerk with values", func(t *testing.T) {
 		mockVault := &MockVaultHelper{
 			KVSecrets: []vaulthelper.KVSecret{
-				{Key: "clerk_key", Value: "testKey"},
-				{Key: "clerk_public_key", Value: "testPublicKey"},
+				{Key: "clerk-key", Value: "testKey"},
+				{Key: "clerk-public-key", Value: "testPublicKey"},
 			},
 		}
 

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/jackc/pgx/v5"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bugfixes/go-bugfixes/logs"
@@ -176,6 +177,9 @@ func (s *System) GetPGXClient(ctx context.Context) (*pgx.Conn, error) {
 
 	client, err := pgx.Connect(ctx, fmt.Sprintf("postgres://%s:%s@%s:%d/%s", s.Details.User, s.Details.Password, s.Details.Host, s.Details.Port, s.Details.DBName))
 	if err != nil {
+		if strings.Contains(err.Error(), "operation was canceled") {
+			return nil, err
+		}
 		return nil, logs.Errorf("failed to get db client: %v", err)
 	}
 


### PR DESCRIPTION
Rename the Clerk secret key names from `clerk_key` and `clerk_public_key` to
`clerk-key` and `clerk-public-key` respectively. This change aligns the secret
key names with the recommended naming convention.