### PR TITLE
feat(mongo): Upgrade to MongoDB v2.2.1 driver

### DIFF
--- a/database/mongo/mongo_test.go
+++ b/database/mongo/mongo_test.go
@@ -116,7 +116,7 @@ func TestMockMungoClient_Connect(t *testing.T) {
 	assert.NoError(t, err)
 
 	mu := RealMongoOperations{}
-	conn, err := mu.GetMongoClient(ctx, *mo)
+	conn, err := mu.GetMongoClient(*mo)
 	assert.NoError(t, err)
 	defer func() {
 		if conn != nil {

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	go.mongodb.org/mongo-driver/v2 v2.2.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=
 go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver/v2 v2.2.1 h1:w5xra3yyu/sGrziMzK1D0cRRaH/b7lWCSsoN6+WV6AM=
+go.mongodb.org/mongo-driver/v2 v2.2.1/go.mod h1:qQkDMhCGWl3FN509DfdPd4GRBLU/41zqF/k8eTRceps=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 h1:jq9TW8u3so/bN+JPT166wjOI6/vQPF6Xe7nMNIltagk=


### PR DESCRIPTION
Upgrade the MongoDB driver to the latest version (v2.2.1) to take advantage of
the latest features and bug fixes. This includes changes to the import paths
and the way the client is created. The `GetMongoClient` function has been
updated to use the new driver version and set the read preference to
`SecondaryPreferred` to improve read availability in a replica set
environment.