### PR TITLE
fix(database): support both postgres and postgresql schemes

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -252,7 +252,7 @@ func (s *System) ParseConnectionString(connStr string) error {
 	if err != nil {
 		return logs.Errorf("failed to parse connection string: %v", err)
 	}
-	if str.Scheme != "postgres" {
+	if str.Scheme != "postgres" && str.Scheme != "postgresql" {
 		return logs.Errorf("invalid connection string scheme: %s", str.Scheme)
 	}
 


### PR DESCRIPTION
Allow connection strings with scheme "postgresql" in addition to
"postgres" to improve compatibility with different PostgreSQL URI
formats. This change prevents errors when parsing valid connection
strings that use the "postgresql" scheme.