### PR TITLE
feat(config): add flags subsystem with env var support

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package ConfigBuilder
 
 import (
 	"github.com/keloran/go-config/auth/clerk"
+	"github.com/keloran/go-config/flags"
 	"github.com/keloran/go-config/notify/resend"
 	"net/http"
 
@@ -33,6 +34,7 @@ type Config struct {
 	Bugfixes bugfixes.System
 	Clerk    clerk.System
 	Resend   resend.System
+	Flags    flags.System
 
 	// Project level properties
 	ProjectProperties map[string]interface{}
@@ -260,6 +262,15 @@ func Bugfixes(cfg *Config) error {
 	b.Logger = bf
 
 	cfg.Bugfixes = *b
+	return nil
+}
+
+func Flags(cfg *Config) error {
+	f, err := flags.Build()
+	if err != nil {
+		return logs.Errorf("failed to build flags: %v", err)
+	}
+	cfg.Flags = *f
 	return nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -252,6 +252,17 @@ func TestBugfixes(t *testing.T) {
 	assert.Equal(t, "testSecret", cfg.Bugfixes.Logger.Secret)
 }
 
+func TestFlags(t *testing.T) {
+	os.Clearenv()
+	if err := os.Setenv("FLAGS_AGENT_ID", "agentId"); err != nil {
+		assert.NoError(t, err)
+	}
+
+	cfg, err := Build(Flags)
+	assert.NoError(t, err)
+	assert.Equal(t, "agentId", cfg.Flags.AgentID)
+}
+
 func TestClerk(t *testing.T) {
 	t.Run("clerk no set values", func(t *testing.T) {
 		os.Clearenv()

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -1,0 +1,29 @@
+package flags
+
+import (
+	"github.com/bugfixes/go-bugfixes/logs"
+	"github.com/caarlos0/env/v8"
+)
+
+type System struct {
+	ProjectID     string `env:"FLAGS_PROJECT_ID" envDefault:""`
+	AgentID       string `env:"FLAGS_AGENT_ID" envDefault:""`
+	EnvironmentID string `env:"FLAGS_ENVIRONMENT_ID" envDefault:""`
+}
+
+func NewSystem() *System {
+	return &System{}
+}
+
+func Build() (*System, error) {
+	f := NewSystem()
+	return f.buildLocal()
+}
+
+func (s *System) buildLocal() (*System, error) {
+	if err := env.Parse(s); err != nil {
+		return s, logs.Errorf("failed to parse flags config: %v", err)
+	}
+
+	return s, nil
+}

--- a/flags/flags_test.go
+++ b/flags/flags_test.go
@@ -1,0 +1,39 @@
+package flags
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestBuild(t *testing.T) {
+	t.Run("default values", func(t *testing.T) {
+		os.Clearenv()
+
+		f, err := Build()
+		assert.NoError(t, err)
+		assert.Equal(t, "", f.AgentID)
+		assert.Equal(t, "", f.EnvironmentID)
+		assert.Equal(t, "", f.ProjectID)
+	})
+
+	t.Run("custom values", func(t *testing.T) {
+		os.Clearenv()
+
+		if err := os.Setenv("FLAGS_ENVIRONMENT_ID", "envId"); err != nil {
+			assert.NoError(t, err)
+		}
+		if err := os.Setenv("FLAGS_PROJECT_ID", "projId"); err != nil {
+			assert.NoError(t, err)
+		}
+		if err := os.Setenv("FLAGS_AGENT_ID", "agentId"); err != nil {
+			assert.NoError(t, err)
+		}
+
+		f, err := Build()
+		assert.NoError(t, err)
+		assert.Equal(t, "envId", f.EnvironmentID)
+		assert.Equal(t, "projId", f.ProjectID)
+		assert.Equal(t, "agentId", f.AgentID)
+	})
+}

--- a/local/local.go
+++ b/local/local.go
@@ -17,7 +17,7 @@ type System struct {
 	EnvMap      map[string]string
 }
 
-func NewLocal(local, dev bool, http, grpc int) *System {
+func NewSystem(local, dev bool, http, grpc int) *System {
 	return &System{
 		KeepLocal:   local,
 		Development: dev,
@@ -27,7 +27,7 @@ func NewLocal(local, dev bool, http, grpc int) *System {
 }
 
 func Build() (*System, error) {
-	l := NewLocal(false, false, 80, 3000)
+	l := NewSystem(false, false, 80, 3000)
 	if err := env.Parse(l); err != nil {
 		return l, logs.Errorf("failed to parse local config: %v", err)
 	}


### PR DESCRIPTION
Introduce a new flags package to parse FLAGS_* environment variables
(ProjectID, AgentID, EnvironmentID) into a dedicated Flags config section.

Integrate Flags into the main Config struct and build process to enable
flag-based configuration. Add tests to verify correct parsing and loading
of flag environment variables.

Rename NewLocal to NewSystem for clarity in local config construction.